### PR TITLE
feat: Save figures to figures directory 

### DIFF
--- a/materialize_branches.ipynb
+++ b/materialize_branches.ipynb
@@ -64,6 +64,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "170ef065-56ca-4da5-ac5e-824f589d4487",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "figures_dir = Path.cwd() / \"figures\"\n",
+    "figures_dir.mkdir(exist_ok=True)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "d7dc48bd-585e-4c95-848b-3a59dc920f51",
    "metadata": {},
@@ -631,7 +642,7 @@
    "source": [
     "event_rate_in_kHz = nevts / np.fromiter(time_per_fraction_read.values(), np.float32) / 1_000\n",
     "\n",
-    "fig, (ax0, ax1) = plt.subplots(figsize=(12,4), ncols=2)\n",
+    "fig, (ax0, ax1) = plt.subplots(figsize=(11,4), ncols=2)\n",
     "\n",
     "ax0.plot(time_per_fraction_read.keys(), time_per_fraction_read.values(), \"o\")\n",
     "ax0.set_xlabel(\"fraction read\")\n",
@@ -643,7 +654,10 @@
     "ax1.set_xlabel(\"fraction read\")\n",
     "ax1.set_ylabel(\"event rate [kHz]\")\n",
     "ax1.set_xlim([0, ax1.get_xlim()[1]])\n",
-    "ax1.set_ylim([0, ax1.get_ylim()[1]])"
+    "ax1.set_ylim([0, ax1.get_ylim()[1]])\n",
+    "\n",
+    "fig.tight_layout()\n",
+    "fig.savefig(figures_dir / \"file_read_time.png\", dpi=300)"
    ]
   },
   {
@@ -674,7 +688,9 @@
     "ax.set_xlabel(\"fraction read\")\n",
     "ax.set_ylabel(\"rate [Mbps]\")\n",
     "ax.set_xlim([0, ax.get_xlim()[1]])\n",
-    "ax.set_ylim([0, ax.get_ylim()[1]])"
+    "ax.set_ylim([0, ax.get_ylim()[1]])\n",
+    "\n",
+    "fig.savefig(figures_dir / \"file_read_rate.png\", dpi=300)"
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.jupytext]
+# Always pair ipynb notebooks to py:percent files
+formats = ["ipynb", "py:percent"]
+notebook_metadata_filter = "all,-jupytext.text_representation.jupytext_version,-language_info.version"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,6 @@ snakeviz
 
 # What was needed on UChicago jupyter
 # func_adl_servicex_xaodr21>=2.0a1
+
+# developer tools
+jupytext


### PR DESCRIPTION
This PR targets PR #28 instead of `main` to avoid noise and needing to deal with merge conflicts and Jupyter notebooks.

* Ensure a figures directory exists to save to.
* Save figures as PNG files with dpi of 300 to have them be high enough quality as to be readable.
* Use the `tight_layout` for the two column figure and slightly decrease the figure width to still look good without having the plot be too wide.

Optional other components (can be factored out to another PR &mdash; happy to do so too):

* Add jupytext to requirements file.
* Add pyproject.toml with jupytext config.
   - Pair ipynb notebooks to py:percent files.
   - Ignore the jupytext_version and Python version as these are not informative metadata.