### PR TITLE
feat: optimize graph to reduce number of nodes and save pre-processing report

### DIFF
--- a/materialize_branches.ipynb
+++ b/materialize_branches.ipynb
@@ -365,7 +365,8 @@
     "# fname = \"root://192.170.240.143//root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/mc20_13TeV/6e/cf/DAOD_PHYSLITE.37230006._000001.pool.root.1\"\n",
     "# treename = \"CollectionTree\"\n",
     "# events = NanoEventsFactory.from_root({fname: treename}, schemaclass=PHYSLITESchema).events()\n",
-    "# task = materialize_branches(events)"
+    "# task = materialize_branches(events)\n",
+    "# task[\"_counter\"].compute()"
    ]
   }
  ],

--- a/materialize_branches.ipynb
+++ b/materialize_branches.ipynb
@@ -12,11 +12,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "awkward: 2.6.2\n",
+      "awkward: 2.6.3\n",
       "dask-awkward: 2024.3.0\n",
       "uproot: 5.3.2\n",
       "hist: 2.7.2\n",
-      "coffea: 2024.3.0\n"
+      "coffea: 2024.4.1\n"
      ]
     }
    ],
@@ -53,7 +53,7 @@
     "# client = Client(cluster)\n",
     "\n",
     "# for UChicago\n",
-    "client = Client(\"tcp://dask-alheld-c58c6d0f-b.af-jupyter:8786\")  # update this to point to your own client!\n",
+    "client = Client(\"tcp://dask-alheld-2ec78772-d.af-jupyter:8786\")  # update this to point to your own client!\n",
     "\n",
     "print(f\"awkward: {ak.__version__}\")\n",
     "print(f\"dask-awkward: {dak.__version__}\")\n",
@@ -184,7 +184,16 @@
     "            branch_data = events[obj_name, obj_prop]\n",
     "        else:\n",
     "            branch_data = events[obj_name, obj_prop][\"m_persIndex\"]\n",
-    "        _counter += ak.count_nonzero(branch_data)\n",
+    "\n",
+    "        _counter_to_add = ak.count_nonzero(branch_data, axis=-1)  # reduce innermost\n",
+    "\n",
+    "        # reduce >2-dimensional (per event) branches further\n",
+    "        for _ in range(_counter_to_add.ndim - 1):\n",
+    "            _counter_to_add = ak.count_nonzero(_counter_to_add, axis=-1)\n",
+    "\n",
+    "        _counter = _counter + _counter_to_add  # sum 1-dim array built from new branch\n",
+    "\n",
+    "    _counter = ak.count_nonzero(_counter, axis=0)  # reduce to int\n",
     "\n",
     "    return {\"nevts\": num_events, \"_counter\": _counter}"
    ]
@@ -201,15 +210,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 122 ms, sys: 13.5 ms, total: 136 ms\n",
-      "Wall time: 20 s\n"
+      "CPU times: user 221 ms, sys: 59.7 ms, total: 280 ms\n",
+      "Wall time: 32.9 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "# pre-process\n",
-    "samples, report = dataset_tools.preprocess(fileset, skip_bad_files=True, uproot_options={\"allow_read_errors_with_report\": True})"
+    "with performance_report(filename=\"dask-report-preprocess.html\"):\n",
+    "    samples, report = dataset_tools.preprocess(fileset, skip_bad_files=True, uproot_options={\"allow_read_errors_with_report\": True})"
    ]
   },
   {
@@ -238,8 +248,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3.42 s, sys: 79.1 ms, total: 3.5 s\n",
-      "Wall time: 3.5 s\n"
+      "CPU times: user 3.49 s, sys: 96.2 ms, total: 3.59 s\n",
+      "Wall time: 3.59 s\n"
      ]
     }
    ],
@@ -266,10 +276,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "total time spent in uproot reading data: 449.08 s\n",
-      "wall time: 62.38s\n",
-      "CPU times: user 537 ms, sys: 67.4 ms, total: 605 ms\n",
-      "Wall time: 1min 2s\n"
+      "total time spent in uproot reading data: 360.42 s\n",
+      "wall time: 24.95s\n",
+      "CPU times: user 563 ms, sys: 18.2 ms, total: 581 ms\n",
+      "Wall time: 24.9 s\n"
      ]
     }
    ],
@@ -277,7 +287,7 @@
     "%%time\n",
     "# execute task graph\n",
     "t0 = time.perf_counter()\n",
-    "with performance_report(filename=\"dask-report.html\"):\n",
+    "with performance_report(filename=\"dask-report-compute.html\"):\n",
     "    ((out, report),) = dask.compute(tasks)  # feels strange that this is a tuple-of-tuple\n",
     "t1 = time.perf_counter()\n",
     "\n",
@@ -295,11 +305,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "output: {'ttbar': {'nevts': 710000, '_counter': 469279029}}\n",
+      "output: {'ttbar': {'nevts': 710000, '_counter': 710000}}\n",
       "\n",
       "performance metrics:\n",
-      " - event rate: 11.38 kHz\n",
-      " - read 2304.02 MB in 62.38 s -> 295.47 Mbps (need to scale by x677 to reach 200 Gbps)\n"
+      " - event rate: 28.46 kHz\n",
+      " - read 1603.23 MB in 24.95 s -> 514.15 Mbps (need to scale by x389 to reach 200 Gbps)\n"
      ]
     }
    ],
@@ -352,11 +362,10 @@
    "outputs": [],
    "source": [
     "# if issues with files exist, paste in path and reproduce\n",
-    "# fname = \"root://192.170.240.146:1094//root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/mc20_13TeV/59/28/DAOD_PHYSLITE.37231868._000040.pool.root.1\"\n",
+    "# fname = \"root://192.170.240.143//root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/mc20_13TeV/6e/cf/DAOD_PHYSLITE.37230006._000001.pool.root.1\"\n",
     "# treename = \"CollectionTree\"\n",
     "# events = NanoEventsFactory.from_root({fname: treename}, schemaclass=PHYSLITESchema).events()\n",
-    "# task = materialize_branches(events)\n",
-    "# task[\"_counter\"].compute()"
+    "# task = materialize_branches(events)"
    ]
   }
  ],


### PR DESCRIPTION
Resolves #42: optimize the way in which we read all the content from the files to significantly reduce the number of nodes created in the graph. See https://github.com/dask-contrib/dask-awkward/issues/499 for more context. For an example with 750 files, we now have 750 nodes at the lowest level compared to 61.5k nodes previously.

Resolves #39: save pre-processing reports as separate file.