### PR TITLE
Smarter way to count branches

### DIFF
--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -271,6 +271,7 @@ def main(
 
     # Do the calc now.
     logging.info(f"Number of tasks in the dask graph: {len(total_count.dask)}")  # type: ignore
+    total_count.visualize(optimize_graph=True)  # type: ignore
     logging.info("Computing the total count")
     if dask_report:
         with performance_report(filename="dask-report.html"):

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -271,7 +271,7 @@ def main(
 
     # Do the calc now.
     logging.info(f"Number of tasks in the dask graph: {len(total_count.dask)}")  # type: ignore
-    total_count.visualize(optimize_graph=True)  # type: ignore
+    # total_count.visualize(optimize_graph=True)  # type: ignore
     logging.info("Computing the total count")
     if dask_report:
         with performance_report(filename="dask-report.html"):


### PR DESCRIPTION
* Move to using `count_nonzero` one per axis to reduce # of tasks.
* This requires some iterative work for the counting rather than the straight forward signle line from before.

On a 2 file run this goes from 2230 tasks to 2228. Hmmm....

Fixes #48
