### PR TITLE
Allow DASK read errors

### DIFF
--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -308,7 +308,7 @@ Note on the dataset argument: \n
         "--download-sx-result",
         action="store_true",
         help="Download the result from ServiceX. If not specified, the result will be "
-        "read directly from SX's S3 instance.",
+        "read directly from SX's S3 instance. Likely only used during remote debugging.",
     )
 
     # Add the flag to enable/disable local Dask cluster

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -257,6 +257,7 @@ def main(
 
     logging.info(f"Done: result = {r:,}")
 
+    # Scan through for any exceptions that happened during the dask processing.
     report_list = report_to_be.compute()
     for process in report_list:
         if process.exception is not None:


### PR DESCRIPTION
Address possible read-errors from S3 during the processing of the "physics". In general this is likely not the right way to address errors, but it will help run the tests especially when we are near the edge of a facility's capability.

- Add code to always allow `uproot` read errors
- Added the `--download` option which will download locally files rather than run out of S3. This improves debugging when not running close to S3.

Fixes #46