### PR TITLE
fix: error reporting with `uproot.open` tasks

### DIFF
--- a/materialize_branches.ipynb
+++ b/materialize_branches.ipynb
@@ -518,7 +518,8 @@
     "# fname = \"root://192.170.240.143//root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/mc20_13TeV/6e/cf/DAOD_PHYSLITE.37230006._000001.pool.root.1\"\n",
     "# treename = \"CollectionTree\"\n",
     "# events = NanoEventsFactory.from_root({fname: treename}, schemaclass=PHYSLITESchema).events()\n",
-    "# task = materialize_branches(events)"
+    "# task = materialize_branches(events)\n",
+    "# task[\"_counter\"].compute()"
    ]
   },
   {

--- a/materialize_branches.ipynb
+++ b/materialize_branches.ipynb
@@ -163,33 +163,31 @@
     "        \"AnalysisMuonsAuxDyn.ptcone20_Nonprompt_All_MaxWeightTTVA_pt1000\",\n",
     "        \"AnalysisElectronsAuxDyn.ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500\", \"AnalysisMuonsAuxDyn.CaloLRLikelihood\"\n",
     "    ]\n",
-    "    \n",
+    "\n",
     "    filter_name = lambda x: x in BRANCH_LIST\n",
     "\n",
     "    size_uncompressed = 0\n",
-    "    failed = []\n",
-    "    succeeded = []\n",
     "    t0 = time.perf_counter()\n",
     "    try:\n",
     "        with uproot.open(fname, filter_name=filter_name) as f:\n",
     "            num_entries = f[\"CollectionTree\"].num_entries\n",
     "            for b in BRANCH_LIST:\n",
-    "                print(b)\n",
     "                f[\"CollectionTree\"][b].array()\n",
     "                size_uncompressed += f[\"CollectionTree\"][b].uncompressed_bytes\n",
-    "    \n",
+    "\n",
     "            size_read = f.file.source.num_requested_bytes\n",
-    "        succeeded.append(fname)\n",
-    "        \n",
+    "        exception = None\n",
+    "\n",
     "    except:\n",
     "        num_entries = 0\n",
     "        size_read = 0\n",
     "        size_uncompressed = 0\n",
-    "        failed.append({fname: traceback.format_exc()})\n",
+    "        exception = traceback.format_exc()\n",
     "\n",
     "    t1 = time.perf_counter()\n",
     "    time_finished = datetime.datetime.now()\n",
-    "    return {\"read\": size_read, \"uncompressed\": size_uncompressed, \"num_entries\": num_entries, \"runtime\": t1-t0, \"time_finished\": time_finished, \"succeeded\": succeeded, \"failed\": failed}"
+    "    return {\"fname\": fname, \"read\": size_read, \"uncompressed\": size_uncompressed, \"num_entries\": num_entries,\n",
+    "            \"runtime\": t1-t0, \"time_finished\": time_finished, \"exception\": exception}"
    ]
   },
   {
@@ -259,16 +257,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22fdb912-31f7-48fd-bd40-b9f3fd5fc79a",
+   "id": "136da759-b7ea-49c2-afab-fe4e12c5422e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# list problems\n",
-    "for i, report in enumerate(out[\"failed\"]):\n",
-    "    if len(report) == 0:\n",
-    "        continue\n",
-    "    for field in report.fields:\n",
-    "        print(f\"{field} failed in {out[i]['runtime']:.2f} s\\n{report[field][0]}\\n\")"
+    "print(f\"{sum(o is not None for o in out['exception'])} files failed\\n\")\n",
+    "\n",
+    "# use below to get full list with details\n",
+    "# for report in out:\n",
+    "#     if report[\"exception\"] is not None:\n",
+    "#         print(f\"{report['fname']} failed in {report['runtime']:.2f} s\\n{report['exception']}\\n\")"
    ]
   },
   {
@@ -517,10 +515,10 @@
    "outputs": [],
    "source": [
     "# if issues with files exist, paste in path and reproduce\n",
-    "# fname = \"root://192.170.240.143//root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/mc20_13TeV/6e/cf/DAOD_PHYSLITE.37230006._000001.pool.root.1\"\n",
-    "# treename = \"CollectionTree\"\n",
-    "# events = NanoEventsFactory.from_root({fname: treename}, schemaclass=PHYSLITESchema).events()\n",
-    "# task = materialize_branches(events)\n",
+    "fname = \"root://192.170.240.148//root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/mc20_13TeV/f5/99/DAOD_PHYSLITE.37230013._001196.pool.root.1\"\n",
+    "treename = \"CollectionTree\"\n",
+    "events = NanoEventsFactory.from_root({fname: treename}, schemaclass=PHYSLITESchema).events()\n",
+    "task = materialize_branches(events)\n",
     "# task[\"_counter\"].compute()"
    ]
   },

--- a/materialize_branches.ipynb
+++ b/materialize_branches.ipynb
@@ -515,11 +515,10 @@
    "outputs": [],
    "source": [
     "# if issues with files exist, paste in path and reproduce\n",
-    "fname = \"root://192.170.240.148//root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/mc20_13TeV/f5/99/DAOD_PHYSLITE.37230013._001196.pool.root.1\"\n",
-    "treename = \"CollectionTree\"\n",
-    "events = NanoEventsFactory.from_root({fname: treename}, schemaclass=PHYSLITESchema).events()\n",
-    "task = materialize_branches(events)\n",
-    "# task[\"_counter\"].compute()"
+    "# fname = \"root://192.170.240.143//root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/mc20_13TeV/6e/cf/DAOD_PHYSLITE.37230006._000001.pool.root.1\"\n",
+    "# treename = \"CollectionTree\"\n",
+    "# events = NanoEventsFactory.from_root({fname: treename}, schemaclass=PHYSLITESchema).events()\n",
+    "# task = materialize_branches(events)"
    ]
   },
   {


### PR DESCRIPTION
Simplify the error reporting to fix some of the issues with too many files getting listed as having been involved in errors.