### PR TITLE
Add library of queries

### DIFF
--- a/servicex/query_library.py
+++ b/servicex/query_library.py
@@ -43,133 +43,137 @@ def build_xaod_query(q_type: str) -> FuncADLQuery:
     # TODO: The EventInfo argument should default correctly
     #       (that may just be a matter of using func_adl xaod r22)
     # TODO: dataclass should be supported so as not to lose type-following!
-    # TODO: once https://github.com/iris-hep/func_adl/issues/136 fixed, turn off fmt off.
-    # fmt: off
-    query = (ds.Select(lambda e: {
+
+    # Build the event model.
+    event_model = ds.Select(
+        lambda e: {
             "evt": e.EventInfo("EventInfo"),
             "jet": e.Jets(),
-        })
-        .Select(lambda ei: {
+        }
+    )
+
+    # Apply slimming and skimming
+    # TODO: New servicex frontend does not know how to return transformation error
+    #       when you have a malformed query and the code generator errors out.
+    # TODO: The SX dashboard, when it has stuck transforms, becomes an unsorted mess
+    #       of failed and successful queries. It would be nice if dead queries were
+    #       sorted to the bottom or something similar.
+    def skim_jets(events, jet_cut: float):
+        return events.Select(
+            lambda e: {
+                "evt": e.evt,
+                "jet": e.jet.Where(
+                    lambda j: (j.pt() / 1000 > jet_cut) and (abs(j.eta()) < 2.5)
+                ),
+            }
+        )
+
+    def count_jets(events, n_jets: int):
+        return events.Where(lambda e: len(e.jet) >= n_jets)
+
+    if q_type == "medium":
+        event_model = skim_jets(event_model, 25.0)
+
+    if q_type == "small":
+        event_model = skim_jets(event_model, 50.0)
+
+    if q_type == "small" or q_type == "medium":
+        event_model = count_jets(event_model, 4)
+
+    # Get out the data we need
+    query = event_model.Select(
+        lambda ei: {
             "event_number": ei.evt.eventNumber(),  # type: ignore
             "run_number": ei.evt.runNumber(),  # type: ignore
             "jet_pt": ei.jet.Select(lambda j: j.pt() / 1000),  # type: ignore
             "jet_eta": ei.jet.Select(lambda j: j.eta()),  # type: ignore
             "jet_phi": ei.jet.Select(lambda j: j.phi()),  # type: ignore
             "jet_m": ei.jet.Select(lambda j: j.m()),  # type: ignore
-            "jet_EnergyPerSampling":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_vfloat]("EnergyPerSampling")
-                ),
-            "jet_SumPtTrkPt500":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_vfloat]("SumPtTrkPt500")
-                ),
-            "jet_TrackWidthPt1000":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_vfloat]("TrackWidthPt1000")
-                ),
-            "jet_NumTrkPt500":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_vint]("NumTrkPt500")
-                ),
-            "jet_NumTrkPt1000":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_vint]("NumTrkPt1000")
-                ),
-            "jet_SumPtChargedPFOPt500":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_vfloat]("SumPtChargedPFOPt500")
-                ),
-            "jet_Timing":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("Timing")
-                ),
-            "jet_JetConstitScaleMomentum_eta":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_eta")
-                ),
-            "jet_ActiveArea4vec_eta":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_eta")
-                ),
-            "jet_DetectorEta":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("DetectorEta")
-                ),
-            "jet_JetConstitScaleMomentum_phi":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_phi")
-                ),
-            "jet_ActiveArea4vec_phi":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_phi")
-                ),
-            "jet_JetConstitScaleMomentum_m":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_m")
-                ),
-            "jet_JetConstitScaleMomentum_pt":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_pt")
-                ),
-            "jet_Width":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("Width")
-                ),
-            "jet_EMFrac":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("EMFrac")
-                ),
-            "jet_ActiveArea4vec_m":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_m")
-                ),
-            "jet_DFCommonJets_QGTagger_TracksWidth":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("DFCommonJets_QGTagger_TracksWidth")
-                ),
-            "jet_JVFCorr":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("JVFCorr")
-                ),
-            "jet_DFCommonJets_QGTagger_TracksC1":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("DFCommonJets_QGTagger_TracksC1")
-                ),
-            "jet_PSFrac":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("PSFrac")
-                ),
-            "jet_DFCommonJets_QGTagger_NTracks":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_int]("DFCommonJets_QGTagger_NTracks")
-                ),
-            "jet_DFCommonJets_fJvt":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("DFCommonJets_fJvt")
-                ),
-            "jet_PartonTruthLabelID":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_int]("PartonTruthLabelID")
-                ),
-            "jet_HadronConeExclExtendedTruthLabelID":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_int]("HadronConeExclExtendedTruthLabelID")
-                ),
-            "jet_ConeTruthLabelID":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_int]("ConeTruthLabelID")
-                ),
-            "jet_HadronConeExclTruthLabelID":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_int]("HadronConeExclTruthLabelID")
-                ),
-            "jet_ActiveArea4vec_pt":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_pt")
-                ),
-        })
+            "jet_EnergyPerSampling": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_vfloat]("EnergyPerSampling")
+            ),
+            "jet_SumPtTrkPt500": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_vfloat]("SumPtTrkPt500")
+            ),
+            "jet_TrackWidthPt1000": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_vfloat]("TrackWidthPt1000")
+            ),
+            "jet_NumTrkPt500": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_vint]("NumTrkPt500")
+            ),
+            "jet_NumTrkPt1000": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_vint]("NumTrkPt1000")
+            ),
+            "jet_SumPtChargedPFOPt500": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_vfloat]("SumPtChargedPFOPt500")
+            ),
+            "jet_Timing": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("Timing")
+            ),
+            "jet_JetConstitScaleMomentum_eta": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_eta")
+            ),
+            "jet_ActiveArea4vec_eta": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_eta")
+            ),
+            "jet_DetectorEta": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("DetectorEta")
+            ),
+            "jet_JetConstitScaleMomentum_phi": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_phi")
+            ),
+            "jet_ActiveArea4vec_phi": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_phi")
+            ),
+            "jet_JetConstitScaleMomentum_m": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_m")
+            ),
+            "jet_JetConstitScaleMomentum_pt": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_pt")
+            ),
+            "jet_Width": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("Width")
+            ),
+            "jet_EMFrac": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("EMFrac")
+            ),
+            "jet_ActiveArea4vec_m": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_m")
+            ),
+            "jet_DFCommonJets_QGTagger_TracksWidth": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("DFCommonJets_QGTagger_TracksWidth")
+            ),
+            "jet_JVFCorr": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("JVFCorr")
+            ),
+            "jet_DFCommonJets_QGTagger_TracksC1": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("DFCommonJets_QGTagger_TracksC1")
+            ),
+            "jet_PSFrac": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("PSFrac")
+            ),
+            "jet_DFCommonJets_QGTagger_NTracks": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_int]("DFCommonJets_QGTagger_NTracks")
+            ),
+            "jet_DFCommonJets_fJvt": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("DFCommonJets_fJvt")
+            ),
+            "jet_PartonTruthLabelID": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_int]("PartonTruthLabelID")
+            ),
+            "jet_HadronConeExclExtendedTruthLabelID": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_int]("HadronConeExclExtendedTruthLabelID")
+            ),
+            "jet_ConeTruthLabelID": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_int]("ConeTruthLabelID")
+            ),
+            "jet_HadronConeExclTruthLabelID": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_int]("HadronConeExclTruthLabelID")
+            ),
+            "jet_ActiveArea4vec_pt": ei.jet.Select(  # type: ignore
+                lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_pt")
+            ),
+        }
     )
-    # fmt: on
 
     return query

--- a/servicex/query_library.py
+++ b/servicex/query_library.py
@@ -1,0 +1,151 @@
+import logging
+from func_adl_servicex_xaodr22 import (
+    FuncADLQueryPHYSLITE,
+    cpp_float,
+    cpp_int,
+    cpp_vfloat,
+    cpp_vint,
+    atlas_release,
+)
+
+
+def query_all() -> FuncADLQueryPHYSLITE:
+    # Because we are going to do a specialized query, we'll alter the return type here.
+    logging.info(f"Using release {atlas_release} for type information.")
+
+    ds = FuncADLQueryPHYSLITE()
+
+    # Build the query
+    # TODO: The EventInfo argument should default correctly
+    #       (that may just be a matter of using func_adl xaod r22)
+    # TODO: dataclass should be supported so as not to lose type-following!
+    # TODO: once https://github.com/iris-hep/func_adl/issues/136 fixed, turn off fmt off.
+    # fmt: off
+    query = (ds.Select(lambda e: {
+            "evt": e.EventInfo("EventInfo"),
+            "jet": e.Jets(),
+        })
+        .Select(lambda ei: {
+            "event_number": ei.evt.eventNumber(),  # type: ignore
+            "run_number": ei.evt.runNumber(),  # type: ignore
+            "jet_pt": ei.jet.Select(lambda j: j.pt() / 1000),  # type: ignore
+            "jet_eta": ei.jet.Select(lambda j: j.eta()),  # type: ignore
+            "jet_phi": ei.jet.Select(lambda j: j.phi()),  # type: ignore
+            "jet_m": ei.jet.Select(lambda j: j.m()),  # type: ignore
+            "jet_EnergyPerSampling":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_vfloat]("EnergyPerSampling")
+                ),
+            "jet_SumPtTrkPt500":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_vfloat]("SumPtTrkPt500")
+                ),
+            "jet_TrackWidthPt1000":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_vfloat]("TrackWidthPt1000")
+                ),
+            "jet_NumTrkPt500":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_vint]("NumTrkPt500")
+                ),
+            "jet_NumTrkPt1000":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_vint]("NumTrkPt1000")
+                ),
+            "jet_SumPtChargedPFOPt500":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_vfloat]("SumPtChargedPFOPt500")
+                ),
+            "jet_Timing":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("Timing")
+                ),
+            "jet_JetConstitScaleMomentum_eta":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_eta")
+                ),
+            "jet_ActiveArea4vec_eta":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_eta")
+                ),
+            "jet_DetectorEta":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("DetectorEta")
+                ),
+            "jet_JetConstitScaleMomentum_phi":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_phi")
+                ),
+            "jet_ActiveArea4vec_phi":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_phi")
+                ),
+            "jet_JetConstitScaleMomentum_m":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_m")
+                ),
+            "jet_JetConstitScaleMomentum_pt":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_pt")
+                ),
+            "jet_Width":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("Width")
+                ),
+            "jet_EMFrac":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("EMFrac")
+                ),
+            "jet_ActiveArea4vec_m":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_m")
+                ),
+            "jet_DFCommonJets_QGTagger_TracksWidth":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("DFCommonJets_QGTagger_TracksWidth")
+                ),
+            "jet_JVFCorr":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("JVFCorr")
+                ),
+            "jet_DFCommonJets_QGTagger_TracksC1":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("DFCommonJets_QGTagger_TracksC1")
+                ),
+            "jet_PSFrac":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("PSFrac")
+                ),
+            "jet_DFCommonJets_QGTagger_NTracks":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_int]("DFCommonJets_QGTagger_NTracks")
+                ),
+            "jet_DFCommonJets_fJvt":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("DFCommonJets_fJvt")
+                ),
+            "jet_PartonTruthLabelID":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_int]("PartonTruthLabelID")
+                ),
+            "jet_HadronConeExclExtendedTruthLabelID":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_int]("HadronConeExclExtendedTruthLabelID")
+                ),
+            "jet_ConeTruthLabelID":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_int]("ConeTruthLabelID")
+                ),
+            "jet_HadronConeExclTruthLabelID":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_int]("HadronConeExclTruthLabelID")
+                ),
+            "jet_ActiveArea4vec_pt":
+                ei.jet.Select(  # type: ignore
+                    lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_pt")
+                ),
+        })
+    )
+    # fmt: on
+
+    return query

--- a/servicex/query_library.py
+++ b/servicex/query_library.py
@@ -7,9 +7,10 @@ from func_adl_servicex_xaodr22 import (
     cpp_vint,
     atlas_release,
 )
+from servicex import FuncADLQuery
 
 
-def query_all() -> FuncADLQueryPHYSLITE:
+def query_all() -> FuncADLQuery:
     # Because we are going to do a specialized query, we'll alter the return type here.
     logging.info(f"Using release {atlas_release} for type information.")
 

--- a/servicex/query_library.py
+++ b/servicex/query_library.py
@@ -10,7 +10,30 @@ from func_adl_servicex_xaodr22 import (
 from servicex import FuncADLQuery
 
 
-def query_all() -> FuncADLQuery:
+def build_query(name: str) -> FuncADLQuery:
+    if name == "xaod_all":
+        return query_xaod_all()
+    elif name == "xaod_medium":
+        return query_xaod_medium()
+    elif name == "xaod_small":
+        return query_xaod_small()
+    else:
+        raise ValueError(f"Unknown query type {name}")
+
+
+def query_xaod_all() -> FuncADLQuery:
+    return build_xaod_query("all")
+
+
+def query_xaod_medium() -> FuncADLQuery:
+    return build_xaod_query("medium")
+
+
+def query_xaod_small() -> FuncADLQuery:
+    return build_xaod_query("small")
+
+
+def build_xaod_query(q_type: str) -> FuncADLQuery:
     # Because we are going to do a specialized query, we'll alter the return type here.
     logging.info(f"Using release {atlas_release} for type information.")
 

--- a/servicex/query_library.py
+++ b/servicex/query_library.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Tuple
 from func_adl_servicex_xaodr22 import (
     FuncADLQueryPHYSLITE,
     cpp_float,
@@ -10,13 +11,13 @@ from func_adl_servicex_xaodr22 import (
 from servicex import FuncADLQuery
 
 
-def build_query(name: str) -> FuncADLQuery:
+def build_query(name: str) -> Tuple[FuncADLQuery, str]:
     if name == "xaod_all":
-        return query_xaod_all()
+        return (query_xaod_all(), "atlasr22")
     elif name == "xaod_medium":
-        return query_xaod_medium()
+        return (query_xaod_medium(), "atlasr22")
     elif name == "xaod_small":
-        return query_xaod_small()
+        return (query_xaod_small(), "atlasr22")
     else:
         raise ValueError(f"Unknown query type {name}")
 

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -10,16 +10,10 @@ import dask
 import dask_awkward as dak
 import uproot
 from dask.distributed import Client, LocalCluster, performance_report
-from func_adl_servicex_xaodr22 import (
-    FuncADLQueryPHYSLITE,
-    atlas_release,
-    cpp_float,
-    cpp_int,
-    cpp_vfloat,
-    cpp_vint,
-)
 
 import servicex as sx
+
+from query_library import query_all
 
 
 class ElapsedFormatter(logging.Formatter):
@@ -50,141 +44,8 @@ def query_servicex(
     else:
         logging.info(f"Running on {num_files} files of dataset.")
 
-    # Because we are going to do a specialized query, we'll alter the return type here.
-    ds = FuncADLQueryPHYSLITE()
-
     # Build the query
-    # TODO: The EventInfo argument should default correctly
-    #       (that may just be a matter of using func_adl xaod r22)
-    # TODO: dataclass should be supported so as not to lose type-following!
-    # TODO: once https://github.com/iris-hep/func_adl/issues/136 fixed, turn off fmt off.
-    # fmt: off
-    query = (ds.Select(lambda e: {
-            "evt": e.EventInfo("EventInfo"),
-            "jet": e.Jets(),
-        })
-        .Select(lambda ei: {
-            "event_number": ei.evt.eventNumber(),  # type: ignore
-            "run_number": ei.evt.runNumber(),  # type: ignore
-            "jet_pt": ei.jet.Select(lambda j: j.pt() / 1000),  # type: ignore
-            "jet_eta": ei.jet.Select(lambda j: j.eta()),  # type: ignore
-            "jet_phi": ei.jet.Select(lambda j: j.phi()),  # type: ignore
-            "jet_m": ei.jet.Select(lambda j: j.m()),  # type: ignore
-            "jet_EnergyPerSampling":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_vfloat]("EnergyPerSampling")
-                ),
-            "jet_SumPtTrkPt500":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_vfloat]("SumPtTrkPt500")
-                ),
-            "jet_TrackWidthPt1000":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_vfloat]("TrackWidthPt1000")
-                ),
-            "jet_NumTrkPt500":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_vint]("NumTrkPt500")
-                ),
-            "jet_NumTrkPt1000":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_vint]("NumTrkPt1000")
-                ),
-            "jet_SumPtChargedPFOPt500":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_vfloat]("SumPtChargedPFOPt500")
-                ),
-            "jet_Timing":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("Timing")
-                ),
-            "jet_JetConstitScaleMomentum_eta":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_eta")
-                ),
-            "jet_ActiveArea4vec_eta":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_eta")
-                ),
-            "jet_DetectorEta":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("DetectorEta")
-                ),
-            "jet_JetConstitScaleMomentum_phi":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_phi")
-                ),
-            "jet_ActiveArea4vec_phi":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_phi")
-                ),
-            "jet_JetConstitScaleMomentum_m":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_m")
-                ),
-            "jet_JetConstitScaleMomentum_pt":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("JetConstitScaleMomentum_pt")
-                ),
-            "jet_Width":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("Width")
-                ),
-            "jet_EMFrac":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("EMFrac")
-                ),
-            "jet_ActiveArea4vec_m":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_m")
-                ),
-            "jet_DFCommonJets_QGTagger_TracksWidth":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("DFCommonJets_QGTagger_TracksWidth")
-                ),
-            "jet_JVFCorr":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("JVFCorr")
-                ),
-            "jet_DFCommonJets_QGTagger_TracksC1":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("DFCommonJets_QGTagger_TracksC1")
-                ),
-            "jet_PSFrac":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("PSFrac")
-                ),
-            "jet_DFCommonJets_QGTagger_NTracks":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_int]("DFCommonJets_QGTagger_NTracks")
-                ),
-            "jet_DFCommonJets_fJvt":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("DFCommonJets_fJvt")
-                ),
-            "jet_PartonTruthLabelID":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_int]("PartonTruthLabelID")
-                ),
-            "jet_HadronConeExclExtendedTruthLabelID":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_int]("HadronConeExclExtendedTruthLabelID")
-                ),
-            "jet_ConeTruthLabelID":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_int]("ConeTruthLabelID")
-                ),
-            "jet_HadronConeExclTruthLabelID":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_int]("HadronConeExclTruthLabelID")
-                ),
-            "jet_ActiveArea4vec_pt":
-                ei.jet.Select(  # type: ignore
-                    lambda j: j.getAttribute[cpp_float]("ActiveArea4vec_pt")
-                ),
-        })
-    )
-    # fmt: on
+    query = query_all()
 
     # Do the query.
     # TODO: Where is the enum that does DeliveryEnum come from?
@@ -230,8 +91,6 @@ def main(
     Load all the branches from some dataset, and then count the flattened
     number of items, and, finally, print them out.
     """
-    logging.info(f"Using release {atlas_release} for type information.")
-
     # Make sure there is a file here to save the SX query ID's to
     # improve performance!
     sx_query_ids = Path("./servicex_query_cache.json")

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -3,7 +3,7 @@ import cProfile
 import logging
 import time
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import awkward as ak
 import dask
@@ -36,7 +36,7 @@ def query_servicex(
     num_files: int,
     ds_name: str,
     download: bool,
-    query: sx.FuncADLQuery,
+    query: Tuple[sx.FuncADLQuery, str],
 ) -> List[str]:
     """Load and execute the servicex query. Returns a complete list of paths
     (be they local or url's) for the root or parquet files.
@@ -58,7 +58,7 @@ def query_servicex(
     spec = sx.ServiceXSpec(
         General=sx.General(
             ServiceX="atlasr22",
-            Codegen="atlasr22",
+            Codegen=query[1],
             OutputFormat=sx.ResultFormat.root,
             Delivery=("LocalCache" if download else "SignedURLs"),
         ),
@@ -66,7 +66,7 @@ def query_servicex(
             sx.Sample(
                 Name=f"speed_test_{ds_name}",
                 RucioDID=ds_name,
-                Query=query,
+                Query=query[0],
                 NFiles=num_files,
                 IgnoreLocalCache=ignore_cache,
             )  # type: ignore
@@ -86,7 +86,7 @@ def main(
     ds_name: Optional[str] = None,
     download_sx_result: bool = False,
     steps_per_file: int = 3,
-    query: Optional[sx.FuncADLQuery] = None,
+    query: Optional[Tuple[sx.FuncADLQuery, str]] = None,
 ):
     """Match the operations found in `materialize_branches` notebook:
     Load all the branches from some dataset, and then count the flattened

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -75,7 +75,6 @@ def query_servicex(
     logging.info("Starting ServiceX query")
     results = sx.deliver(spec)
     assert results is not None
-    print(results.keys())
     return results[f"speed_test_{ds_name}"]
 
 

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -74,6 +74,10 @@ def query_servicex(
     )
 
     logging.info("Starting ServiceX query")
+    # TODO: An info message on the 0001.4961 - INFO - HTTP Request:
+    #       POST https://servicex.af.uchicago.edu//servicex/transformation
+    #       "HTTP/1.1 200 OK"
+    #       Turn that into a debug message perhaps?
     results = sx.deliver(spec)
     assert results is not None
     return results[f"speed_test_{ds_name}"]


### PR DESCRIPTION
* Create a separate file that contains all the queries so we can easily deal with multiple queries. There is support for different codegen's in the future.
* Added a `--query` option that right now takes `xaod_small`, medium, and large
* The cuts ask for jets within a certian eta and pt range, and require a certian nubmer of jets.

A quick table of results for the different cuts running on just a few small files:

| Query | Count output |
| --- | --- |
| xaod_all | 650,000 |
| xaod_medium | 2,325 |
| xaod_small | 12 |

## Minor

* Remove some debug statements leftover from recent efforts.

Fixes #73
