### PR TITLE
Add the module name to the log formatter

### DIFF
--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -22,7 +22,7 @@ class ElapsedFormatter(logging.Formatter):
     started - which makes it easier to understand how long operations took.
     """
 
-    def __init__(self, fmt="%(elapsed)s - %(levelname)s - %(message)s"):
+    def __init__(self, fmt="%(elapsed)s - %(levelname)s - %(module)s - %(message)s"):
         super().__init__(fmt)
         self._start_time = time.time()
 


### PR DESCRIPTION
* Minor change to formatting of log message:

```text
0046.5172 - INFO - servicex_materialize_branches - Field run_number is not a scalar field. Skipping count.
0046.6635 - INFO - servicex_materialize_branches - Number of tasks in the dask graph: optimized: 39 unoptimized 451
0046.6635 - INFO - servicex_materialize_branches - Computing the total count
0047.1996 - INFO - servicex_materialize_branches - Done: result = 2,325
```

Fixes #78