### PR TITLE
Update AB-dev docs

### DIFF
--- a/servicex/README.md
+++ b/servicex/README.md
@@ -67,7 +67,6 @@ This will write out a `sx_materialize_branches.pstats` file, which you can then 
 
 Using the image `AB-dev`
 
-1. `pip install 'func_adl_servicex_xaodr22>=2.0a1'`
 1. `pip install 'git+https://github.com/ssl-hep/ServiceX_frontend@fe6a938e75d4c85d6d0f2e0178969a81fd2ab727'`
 1. Get `servicex.yaml` copied somewhere it will be picked up.
 

--- a/servicex/README.md
+++ b/servicex/README.md
@@ -22,7 +22,7 @@ The following tests were used to run a performance test using the `servicex_mate
         * Use the `AB-dev` image
         * 32 GB of memory
         * 8 cores
-        * From the command line inside the instance, issue the command `pip install 'func_adl_servicex_xaodr22>=2.0a1'`
+        * Follow the instructions below to install what you need.
     2. Once started create a DASK cluster
         * Use the `dask` web page
         * At the bottom click "create"
@@ -68,4 +68,7 @@ This will write out a `sx_materialize_branches.pstats` file, which you can then 
 Using the image `AB-dev`
 
 1. `pip install 'func_adl_servicex_xaodr22>=2.0a1'`
+1. `pip install 'git+https://github.com/ssl-hep/ServiceX_frontend@fe6a938e75d4c85d6d0f2e0178969a81fd2ab727'`
 1. Get `servicex.yaml` copied somewhere it will be picked up.
+
+Note that the `servicex` install will downgrade `pydantic` to version two. Nominally, this is ok, as only `correctionlib` needs it, and none of the SX things use that.


### PR DESCRIPTION
Update instructions for running on `AB-dev` with the 3.0 `servicex` background.

Fixes #77
