### PR TITLE
Adjust steps per file when we are dealing with a small file size.

### DIFF
--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -55,12 +55,14 @@ def query_servicex(
     # TODO: If you change the name of the item you'll get a multiple cache hit!
     # TODO: `servicex cache list` doesn't work and can't figure out how to make it work.
     # TODO: servicex_query_cache.json is being ignored (feature?)
+    # TODO: Why does outputformat and delivery not work as enums? And fail typechecking with
+    #       strings?
     spec = sx.ServiceXSpec(
         General=sx.General(
             ServiceX="atlasr22",
             Codegen=query[1],
-            OutputFormat=sx.ResultFormat.root,
-            Delivery=("LocalCache" if download else "SignedURLs"),
+            OutputFormat=sx.ResultFormat.root,  # type: ignore
+            Delivery=("LocalCache" if download else "SignedURLs"),  # type: ignore
         ),
         Sample=[
             sx.Sample(
@@ -298,6 +300,13 @@ Note on the dataset argument: \n
         logging.debug("Connecting to Dask scheduler at {scheduler_address}")
         assert args.dask_scheduler is not None
         client = Client(args.dask_scheduler)
+        steps_per_file = 2
+
+    # The steps per file needs to be adjusted for uproot 5.3.3 because of a small
+    # bug - also because things start to get inefficient.
+    if args.query == "xaod_small":
+        steps_per_file = 1
+    elif args.query == "xaod_medium":
         steps_per_file = 2
 
     # Determine the dataset

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -55,7 +55,7 @@ def query_servicex(
     # TODO: If you change the name of the item you'll get a multiple cache hit!
     # TODO: `servicex cache list` doesn't work and can't figure out how to make it work.
     # TODO: servicex_query_cache.json is being ignored (feature?)
-    # TODO: Why does outputformat and delivery not work as enums? And fail typechecking with
+    # TODO: Why does OutputFormat and delivery not work as enums? And fail typechecking with
     #       strings?
     spec = sx.ServiceXSpec(
         General=sx.General(

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -240,7 +240,7 @@ Note on the dataset argument: \n
         help="Specify the dataset to use",
     )
 
-    # Add a flag for three queries - xaod_all, xald_medium, xaod_small:
+    # Add a flag for three queries - xaod_all, xaod_medium, xaod_small:
     parser.add_argument(
         "--query",
         choices=["xaod_all", "xaod_medium", "xaod_small"],


### PR DESCRIPTION
This PR fixes bug #87, which was an odd crash deep in uproot.

* We setup the `steps_per_file` depending on what kind of environment we are running on.
* When we cut hard, say with `xaod_small`, we tend to have very little data in the files
* Sometimes, we have seen more steps per file than events, which is likely what causes this bug.

## Changes

* This code adjust `steps_per_file` to 1 for a tight and 2 for medium.
* Fixes spelling and type error as well.

Fixes #87
