### PR TITLE
Run on multiple datasets

### DIFF
--- a/servicex/datasets.py
+++ b/servicex/datasets.py
@@ -1,4 +1,36 @@
-from typing import List
+from pathlib import Path
+from typing import Dict, List
+
+from pydantic import BaseModel, RootModel
+import json
+
+
+class Data(BaseModel):
+    """Data class for single sample."""
+
+    nevts: int
+    nfiles: int
+    size_TB: float
+
+
+class ContainerMetadata(RootModel):
+    """Container metadata class."""
+
+    root: Dict[str, Data]
+
+
+def load_containers() -> Dict[str, Data]:
+    """Load the container metadata.json file.
+
+    Returns:
+        Dict[str, Dict[str, AnyStr]]: Container Metadata for the text files.
+    """
+    metadata_path = (
+        Path(__file__).parent.parent / "input_files" / "container_metadata.json"
+    )
+    with metadata_path.open("r") as f:
+        metadata = json.load(f)
+    return ContainerMetadata.model_validate(metadata).root
 
 
 def determine_dataset(ds_option: str) -> List[str]:
@@ -24,5 +56,17 @@ def determine_dataset(ds_option: str) -> List[str]:
             "mc20_13TeV.364157.Sherpa_221_NNPDF30NNLO_Wmunu_MAXHTPTV0_70_CFilterBVeto.deriv"
             ".DAOD_PHYSLITE.e5340_s3681_r13145_p6026"
         ]
+    elif ds_option == "multi_1TB":
+        all = load_containers()
+        return [k for k, v in all.items() if v.size_TB >= 1.0 and v.size_TB < 2.0]
+    elif ds_option == "multi_small_10":
+        all = load_containers()
+        return [k for k, v in all.items() if v.size_TB < 1.0][0:10]
+    elif ds_option == "multi_small_20":
+        all = load_containers()
+        return [k for k, v in all.items() if v.size_TB < 1.0][0:10]
+    elif ds_option == "all":
+        all = load_containers()
+        return list(all.keys())
     else:
         raise RuntimeError(f"Unknown dataset option: {ds_option}")

--- a/servicex/datasets.py
+++ b/servicex/datasets.py
@@ -1,0 +1,28 @@
+from typing import List
+
+
+def determine_dataset(ds_option: str) -> List[str]:
+    """Return a list of datasets that we will use for testing,
+    depending on the option given on the command line.
+
+    Args:
+        ds_option (str): Option from the command line
+
+    Returns:
+        List[str]: List of datasets.
+    """
+    if ds_option == "mc_10TB":
+        return [
+            "data15_13TeV.periodAllYear.physics_Main.PhysCont.DAOD_PHYSLITE.grp15_v01_p6026"
+        ]
+    elif ds_option == "data_50TB":
+        return [
+            "data18_13TeV.periodAllYear.physics_Main.PhysCont.DAOD_PHYSLITE.grp18_v01_p6026"
+        ]
+    elif ds_option == "mc_1TB":
+        return [
+            "mc20_13TeV.364157.Sherpa_221_NNPDF30NNLO_Wmunu_MAXHTPTV0_70_CFilterBVeto.deriv"
+            ".DAOD_PHYSLITE.e5340_s3681_r13145_p6026"
+        ]
+    else:
+        raise RuntimeError(f"Unknown dataset option: {ds_option}")

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -209,9 +209,9 @@ def calculate_total_count(
 
     n_optimized_tasks = len(dask.optimize(total_count)[0].dask)  # type: ignore
     logging.log(
-        logging.INFO if n_optimized_tasks > 2 else logging.DEBUG,
+        logging.INFO,
         f"{ds_name}: Number of tasks in the dask graph: optimized: "
-        f"{len(dask.optimize(total_count)[0].dask):,} "  # type: ignore
+        f"{n_optimized_tasks:,} "  # type: ignore
         f"unoptimized: {len(total_count.dask):,}",  # type: ignore
     )
 

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -149,11 +149,10 @@ def main(
     all_tasks = {k: v[1] for k, v in all_dask_data.items()}
     if dask_report:
         with performance_report(filename="dask-report.html"):
-            results = dask.compute(*all_tasks.values())
+            results = dask.compute(*all_tasks.values())  # type: ignore
             result_dict = dict(zip(all_tasks.keys(), results))
-            # r = total_count.compute()  # type: ignore
     else:
-        results = dask.compute(*all_tasks.values())
+        results = dask.compute(*all_tasks.values())  # type: ignore
         result_dict = dict(zip(all_tasks.keys(), results))
 
     for k, r in result_dict.items():

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -159,12 +159,15 @@ def main(
         logging.info(f"{k}: result = {r:,}")
 
     # Scan through for any exceptions that happened during the dask processing.
-    # report_list = report_to_be.compute()
-    # for process in report_list:
-    #     if process.exception is not None:
-    #         logging.error(
-    #             f"Exception in process '{process.message}' on file {process.args[0]}"
-    #         )
+    all_report_tasks = {k: v[0] for k, v in all_dask_data.items()}
+    all_reports = dask.compute(*all_report_tasks.values())  # type: ignore
+    for k, report_list in zip(all_report_tasks.keys(), all_reports):
+        for process in report_list:
+            if process.exception is not None:
+                logging.error(
+                    f"Exception in process '{process.message}' on file {process.args[0]} "
+                    "for ds {k}"
+                )
 
 
 def calculate_total_count(steps_per_file: int, files: List[str]) -> Tuple[Any, Any]:

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -52,6 +52,11 @@ def query_servicex(
     # TODO: servicex_query_cache.json is being ignored (feature?)
     # TODO: Why does OutputFormat and delivery not work as enums? And fail typechecking with
     #       strings?
+    # TODO: If some of these submissions work and others do not, we lose the ability to track the
+    #       ones we fired off.
+    #       an example is a title that is longer than 128 characters causes an immediate crash -
+    #       but other queries
+    #       already worked. Cache recovery @ the server would mean this wasn't important.
     spec = sx.ServiceXSpec(
         General=sx.General(
             ServiceX="atlasr22",
@@ -61,7 +66,7 @@ def query_servicex(
         ),
         Sample=[
             sx.Sample(
-                Name=f"speed_test_{ds_name}",
+                Name=f"speed_test_{ds_name}"[0:128],
                 RucioDID=ds_name,
                 Query=query[0],
                 NFiles=num_files,
@@ -80,7 +85,7 @@ def query_servicex(
     logging.info("Starting ServiceX query")
     results = sx.deliver(spec)
     assert results is not None
-    return results[f"speed_test_{ds_name}"]
+    return results[f"speed_test_{ds_names[0]}"[0:128]]
 
 
 def main(
@@ -197,6 +202,10 @@ Note on the dataset argument: \n
   data_50TB - 50 TB of data from dta18. 64803 files.\n
   mc_1TB - 1.2 TB of data from mc20. 232 files.\n
   data_10TB - 10 TB of data from data15. 10049 files.\n
+  multi_1TB - All datasets between 1 and 2 TB.\n
+  multi_small_10 - 10 small datasets (0.1 TB).\n
+  multi_small_20 - 10 small datasets (0.1 TB).\n
+  all - All the datasets.\n
 """,
     )
 
@@ -243,7 +252,15 @@ Note on the dataset argument: \n
     # Add a flag for different datasets
     parser.add_argument(
         "--dataset",
-        choices=["data_50TB", "mc_1TB", "data_10TB"],
+        choices=[
+            "data_50TB",
+            "mc_1TB",
+            "data_10TB",
+            "multi_1TB",
+            "all",
+            "multi_small_10",
+            "multi_small_20",
+        ],
         default="mc_1TB",
         help="Specify the dataset to use",
     )

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -207,10 +207,12 @@ def calculate_total_count(
 
     total_count = ak.count_nonzero(total_count, axis=0)
 
-    logging.info(
+    n_optimized_tasks = len(dask.optimize(total_count)[0].dask)  # type: ignore
+    logging.log(
+        logging.INFO if n_optimized_tasks > 2 else logging.DEBUG,
         f"{ds_name}: Number of tasks in the dask graph: optimized: "
         f"{len(dask.optimize(total_count)[0].dask):,} "  # type: ignore
-        f"unoptimized: {len(total_count.dask):,}"  # type: ignore
+        f"unoptimized: {len(total_count.dask):,}",  # type: ignore
     )
 
     # total_count.visualize(optimize_graph=True)  # type: ignore


### PR DESCRIPTION
* Use Alex's `input_files` list to get a complete list of containers.
* Added a `datasets.py` to grab the datasets.
* Add a few running options so we can run on multiple sets of contrainers (`--help` below).
* Build all the `dask` graphs and then run on them at once.

I've seen a few side effects:
* For multiple datasets we have lots of log messages.
* Sometimes when running with the `xaod_small` cut, we get files with no events in them, even with `steps` set to 1. This ticles the `uproot` bug. If you see that, until a new version of `uproot` is released, you'll need to `pip install git+https://github.com/scikit-hep/uproot5.git@jpivarski/fix-the-bug-gordon-found-on-slack`.

Fixes #90