### PR TITLE
Retry's to fsspec

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ ipywidgets
 # To load from s3 the servicex outputs into uproot, we needed
 # to add a few things by hand! :-(
 fsspec-xrootd
+tenacity
 
 # To look at profiles
 snakeviz

--- a/servicex/fspec_retry.py
+++ b/servicex/fspec_retry.py
@@ -1,0 +1,98 @@
+import logging
+from aiohttp import ClientError
+import fsspec
+from fsspec.implementations.http import (
+    HTTPFile,
+    HTTPFileSystem,
+    HTTPStreamFile,
+    sync,
+    sync_wrapper,
+)
+from tenacity import retry, retry_if_exception_type, wait_random_exponential
+
+
+def register_retry_http_filesystem():
+    """Register the retry version of HTTPFileSystem and HTTPFile with fsspec."""
+    fsspec.register_implementation("http", RetryHTTPFileSystem)
+    fsspec.register_implementation("https", RetryHTTPFileSystem)
+
+
+class RetryHTTPFile(HTTPFile):
+    """Retry version of HTTPFile.
+
+    Defers everything to the parent class except the range read, which is used by uproot.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.old_async_fetch_range = self.async_fetch_range
+
+    @retry(
+        wait=wait_random_exponential(multiplier=1, max=60),
+        retry=retry_if_exception_type(ClientError),
+    )
+    def async_fetch_range(self, start, end):
+        logging.debug(f"retry async_fetch_range: {start} {end}")
+        return super().async_fetch_range(start, end)
+
+    _fetch_range = sync_wrapper(async_fetch_range)
+
+
+class RetryHTTPFileSystem(HTTPFileSystem):
+    """Retry version of HTTPFileSystem."""
+
+    def _open(
+        self,
+        path,
+        mode="rb",
+        block_size=None,
+        autocommit=None,  # XXX: This differs from the base class.
+        cache_type=None,
+        cache_options=None,
+        size=None,
+        **kwargs,
+    ):
+        """Make a file-like object
+
+        Parameters
+        ----------
+        path: str
+            Full URL with protocol
+        mode: string
+            must be "rb"
+        block_size: int or None
+            Bytes to download in one request; use instance value if None. If
+            zero, will return a streaming Requests file-like instance.
+        kwargs: key-value
+            Any other parameters, passed to requests calls
+        """
+        if mode != "rb":
+            raise NotImplementedError
+        block_size = block_size if block_size is not None else self.block_size
+        kw = self.kwargs.copy()
+        kw["asynchronous"] = self.asynchronous
+        kw.update(kwargs)
+        size = size or self.info(path, **kwargs)["size"]
+        session = sync(self.loop, self.set_session)
+        if block_size and size:
+            return RetryHTTPFile(
+                self,
+                path,
+                session=session,
+                block_size=block_size,
+                mode=mode,
+                size=size,
+                cache_type=cache_type or self.cache_type,
+                cache_options=cache_options or self.cache_options,
+                loop=self.loop,
+                **kw,
+            )
+        else:
+            return HTTPStreamFile(
+                self,
+                path,
+                mode=mode,
+                loop=self.loop,
+                session=session,
+                **kw,
+            )

--- a/servicex/fspec_retry.py
+++ b/servicex/fspec_retry.py
@@ -31,17 +31,16 @@ def register_retry_http_filesystem(client):
                 return new_r
 
             self.async_fetch_range = wrap(self.async_fetch_range)
+            self._fetch_range = sync_wrapper(self.async_fetch_range)
             self.read = wrap(self.read)
 
-        def async_fetch_range(self, start, end):
-            logging.debug(f"retry async_fetch_range: {start} {end}")
-            return super().async_fetch_range(start, end)
+        # def async_fetch_range(self, start, end):
+        #     logging.debug(f"retry async_fetch_range: {start} {end}")
+        #     return super().async_fetch_range(start, end)
 
-        _fetch_range = sync_wrapper(async_fetch_range)
-
-        def read(self, length=-1):
-            logging.debug(f"retry read: {length}")
-            return super().read(length)
+        # def read(self, length=-1):
+        #     logging.debug(f"retry read: {length}")
+        #     return super().read(length)
 
     class RetryHTTPFileSystem(HTTPFileSystem):
         """Retry version of HTTPFileSystem."""

--- a/servicex/fspec_retry.py
+++ b/servicex/fspec_retry.py
@@ -1,4 +1,3 @@
-import logging
 import fsspec
 from fsspec.implementations.http import (
     HTTPFile,
@@ -33,14 +32,6 @@ def register_retry_http_filesystem(client):
             self.async_fetch_range = wrap(self.async_fetch_range)
             self._fetch_range = sync_wrapper(self.async_fetch_range)
             self.read = wrap(self.read)
-
-        # def async_fetch_range(self, start, end):
-        #     logging.debug(f"retry async_fetch_range: {start} {end}")
-        #     return super().async_fetch_range(start, end)
-
-        # def read(self, length=-1):
-        #     logging.debug(f"retry read: {length}")
-        #     return super().read(length)
 
     class RetryHTTPFileSystem(HTTPFileSystem):
         """Retry version of HTTPFileSystem."""

--- a/servicex/fspec_retry.py
+++ b/servicex/fspec_retry.py
@@ -8,91 +8,110 @@ from fsspec.implementations.http import (
     sync,
     sync_wrapper,
 )
-from tenacity import retry, retry_if_exception_type, wait_random_exponential
 
 
-def register_retry_http_filesystem():
+def register_retry_http_filesystem(client):
     """Register the retry version of HTTPFileSystem and HTTPFile with fsspec."""
-    fsspec.register_implementation("http", RetryHTTPFileSystem)
-    fsspec.register_implementation("https", RetryHTTPFileSystem)
 
+    import tenacity
 
-class RetryHTTPFile(HTTPFile):
-    """Retry version of HTTPFile.
+    class RetryHTTPFile(HTTPFile):
+        """Retry version of HTTPFile.
 
-    Defers everything to the parent class except the range read, which is used by uproot.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.old_async_fetch_range = self.async_fetch_range
-
-    @retry(
-        wait=wait_random_exponential(multiplier=1, max=60),
-        retry=retry_if_exception_type(ClientError),
-    )
-    def async_fetch_range(self, start, end):
-        logging.debug(f"retry async_fetch_range: {start} {end}")
-        return super().async_fetch_range(start, end)
-
-    _fetch_range = sync_wrapper(async_fetch_range)
-
-
-class RetryHTTPFileSystem(HTTPFileSystem):
-    """Retry version of HTTPFileSystem."""
-
-    def _open(
-        self,
-        path,
-        mode="rb",
-        block_size=None,
-        autocommit=None,  # XXX: This differs from the base class.
-        cache_type=None,
-        cache_options=None,
-        size=None,
-        **kwargs,
-    ):
-        """Make a file-like object
-
-        Parameters
-        ----------
-        path: str
-            Full URL with protocol
-        mode: string
-            must be "rb"
-        block_size: int or None
-            Bytes to download in one request; use instance value if None. If
-            zero, will return a streaming Requests file-like instance.
-        kwargs: key-value
-            Any other parameters, passed to requests calls
+        Defers everything to the parent class except the range read, which is used by uproot.
         """
-        if mode != "rb":
-            raise NotImplementedError
-        block_size = block_size if block_size is not None else self.block_size
-        kw = self.kwargs.copy()
-        kw["asynchronous"] = self.asynchronous
-        kw.update(kwargs)
-        size = size or self.info(path, **kwargs)["size"]
-        session = sync(self.loop, self.set_session)
-        if block_size and size:
-            return RetryHTTPFile(
-                self,
-                path,
-                session=session,
-                block_size=block_size,
-                mode=mode,
-                size=size,
-                cache_type=cache_type or self.cache_type,
-                cache_options=cache_options or self.cache_options,
-                loop=self.loop,
-                **kw,
-            )
-        else:
-            return HTTPStreamFile(
-                self,
-                path,
-                mode=mode,
-                loop=self.loop,
-                session=session,
-                **kw,
-            )
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+            new_r = tenacity.retry(
+                wait=tenacity.wait_random_exponential(multiplier=1, max=60),
+                retry=tenacity.retry_if_exception_type(ClientError),
+                stop=tenacity.stop_after_attempt(30),
+            )(self.async_fetch_range)
+            self.async_fetch_range = new_r
+
+            self.old_async_fetch_range = self.async_fetch_range
+
+        def async_fetch_range(self, start, end):
+            logging.debug(f"retry async_fetch_range: {start} {end}")
+            return super().async_fetch_range(start, end)
+
+        _fetch_range = sync_wrapper(async_fetch_range)
+        pass
+
+    class RetryHTTPFileSystem(HTTPFileSystem):
+        """Retry version of HTTPFileSystem."""
+
+        def _open(
+            self,
+            path,
+            mode="rb",
+            block_size=None,
+            autocommit=None,  # XXX: This differs from the base class.
+            cache_type=None,
+            cache_options=None,
+            size=None,
+            **kwargs,
+        ):
+            """Make a file-like object
+
+            Parameters
+            ----------
+            path: str
+                Full URL with protocol
+            mode: string
+                must be "rb"
+            block_size: int or None
+                Bytes to download in one request; use instance value if None. If
+                zero, will return a streaming Requests file-like instance.
+            kwargs: key-value
+                Any other parameters, passed to requests calls
+            """
+            if mode != "rb":
+                raise NotImplementedError
+            block_size = block_size if block_size is not None else self.block_size
+            kw = self.kwargs.copy()
+            kw["asynchronous"] = self.asynchronous
+            kw.update(kwargs)
+            size = size or self.info(path, **kwargs)["size"]
+            session = sync(self.loop, self.set_session)
+            if block_size and size:
+                return RetryHTTPFile(
+                    self,
+                    path,
+                    session=session,
+                    block_size=block_size,
+                    mode=mode,
+                    size=size,
+                    cache_type=cache_type or self.cache_type,
+                    cache_options=cache_options or self.cache_options,
+                    loop=self.loop,
+                    **kw,
+                )
+            else:
+                return HTTPStreamFile(
+                    self,
+                    path,
+                    mode=mode,
+                    loop=self.loop,
+                    session=session,
+                    **kw,
+                )
+
+    def do_register_retry_http_filesystem():
+        fsspec.register_implementation("http", RetryHTTPFileSystem, clobber=True)
+        fsspec.register_implementation("https", RetryHTTPFileSystem, clobber=True)
+
+    if client is None:
+        do_register_retry_http_filesystem()
+    else:
+
+        def install_tenacity():
+            import subprocess
+            import sys
+
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "tenacity"])
+
+        client.run(install_tenacity)
+        client.run(do_register_retry_http_filesystem)

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -322,10 +322,7 @@ Note on the dataset argument: \n
         steps_per_file = 2
 
     # Register fsspec special http retry filesystem
-    if client is None:
-        register_retry_http_filesystem()
-    else:
-        client.run(register_retry_http_filesystem)
+    register_retry_http_filesystem(client)
 
     # The steps per file needs to be adjusted for uproot 5.3.3 because of a small
     # bug - also because things start to get inefficient.

--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -8,14 +8,13 @@ from typing import List, Optional, Tuple
 import awkward as ak
 import dask
 import dask_awkward as dak
-import fsspec
 import uproot
 from dask.distributed import Client, LocalCluster, performance_report
 
 import servicex as sx
 
 from query_library import build_query
-from fspec_retry import RetryHTTPFileSystem, register_retry_http_filesystem
+from fspec_retry import register_retry_http_filesystem
 
 
 class ElapsedFormatter(logging.Formatter):


### PR DESCRIPTION
* Add captured `fsspec` infrastructure
* Implement the `retry` callback
* Add logging so when bad things happen, we have some sort of record (if messages are collected from the workers!).

While this fix was going on the UChicago S3 interface was upgraded - so even without the `retry` it worked. In timing measurements this seemed to make no difference, however, so it is left in for when we go back to the older configuration.

Fixes #44