### PR TITLE
When nfiles is zero, translate that to a null

### DIFF
--- a/servicex/servicex_materialize_branches.py
+++ b/servicex/servicex_materialize_branches.py
@@ -111,7 +111,7 @@ def query_servicex(
                 RucioDID=ds_name,
                 Codegen=query[1],
                 Query=query[0],
-                NFiles=num_files,
+                NFiles=num_files if num_files > 0 else None,
                 IgnoreLocalCache=ignore_cache,
             )
             for ds_name in ds_names


### PR DESCRIPTION
This change is triggered by the move to the 3.0 release.

* When the number of files requested is zero, translate that to a `None` internally.
* The API for "all files" has changed - it was zero, now it is `None`.

Fixes #159